### PR TITLE
feat: 更新、删除release功能

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
       if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
       uses: ./
       with:
+        gitee_action: create_release
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -84,6 +85,7 @@ jobs:
       if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
       uses: ./
       with:
+        gitee_action: create_release
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -96,10 +98,11 @@ jobs:
           requirements.txt
           .github/workflows/test.yml
           
-    - name: Test upload single file to exist release - using last step id
+    - name: Test upload single file to exist release - using release_id from last step
       if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
       uses: ./
       with:
+        gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -107,10 +110,11 @@ jobs:
         gitee_file_name: ${{ inputs.gitee_file_name_new }}
         gitee_file_path: ${{ inputs.gitee_file_path }}
           
-    - name: Test upload multi file to exist release - using last step id
+    - name: Test upload multi file to exist release - using release_id from last step
       if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
       uses: ./
       with:
+        gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -119,10 +123,11 @@ jobs:
           action.yml
           README.md
           
-    - name: Test upload single file to exist release - using id from inputs
+    - name: Test upload single file to exist release - using release_id from inputs
       if: ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'false' }}
       uses: ./
       with:
+        gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -130,10 +135,11 @@ jobs:
         gitee_file_name: ${{ inputs.gitee_file_name_new }}
         gitee_file_path: ${{ inputs.gitee_file_path }}
         
-    - name: Test upload multi file to exist release - using id from inputs
+    - name: Test upload multi file to exist release - using release_id from inputs
       if: ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'true' }}
       uses: ./
       with:
+        gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -141,3 +147,48 @@ jobs:
         gitee_files: |
           action.yml
           README.md
+
+    - name: Test upload using tag_name
+      if: ${{ inputs.gitee_release_id == '' }}
+      uses: ./
+      with:
+        gitee_action: upload_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: ${{ inputs.gitee_tag_name }}
+        gitee_file_name: 'tag-upload-test.txt'
+        gitee_file_path: 'LICENSE'
+        
+    - name: Test delete asset by tag_name and asset name
+      if: ${{ inputs.gitee_release_id == '' }}
+      uses: ./
+      with:
+        gitee_action: delete_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: ${{ inputs.gitee_tag_name }}
+        gitee_delete_assets: 'tag-upload-test.txt'
+        
+    - name: Test update asset by tag_name
+      if: ${{ inputs.gitee_release_id == '' }}
+      uses: ./
+      with:
+        gitee_action: update_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: ${{ inputs.gitee_tag_name }}
+        gitee_old_asset_name: ${{ inputs.gitee_file_name }}
+        gitee_new_file_path: 'requirements.txt'
+        
+    - name: Test delete release by tag_name
+      if: ${{ inputs.gitee_release_id == '' }}
+      uses: ./
+      with:
+        gitee_action: delete_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: ${{ inputs.gitee_tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Comprehensive Test
 on:
   workflow_dispatch:
     inputs: 
@@ -13,105 +13,108 @@ on:
       gitee_token:
         description: 'Gitee api token'
         required: true
-        
-      gitee_tag_name:
-        description: 'Gitee Tag 名称, 提倡以v字母为前缀做为Release名称，例如v1.0或者v2.3.4'
-        required: false
-        default: v1.0
-      gitee_release_name:
-        description: 'Gitee release 名称'
-        required: false
-        default: Test v1.0
-        
-      test_multi_files:
-        description: '测试多文件'
-        required: true
-        type: boolean
-        default: true
-        
-      gitee_file_name:
-        description: '上传的附件名称'
-        required: false
-        default: '测试.txt'
-      gitee_file_path:
-        description: '上传的附件的本地路径'
-        required: false
-        default: 'LICENSE'
-        
-      gitee_release_id:
-        description: '上传附件对应的release的id。该值存在的话，不会再去尝试创建release。'
-        required: false
-      gitee_file_name_new:
-        description: '第二次上传的附件名称'
-        required: false
-        default: '测试2.txt'
 jobs:
-  release:
+  # Job 1: 测试单文件创建release和相关操作
+  test-single-file:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.ref }}
         
-    - name: Echo inputs
-      run: |
-        echo ${{ github.event.inputs.test_multi_files }}
-        echo ${{ github.event.inputs.test_multi_files == 'false'}}
-        echo ${{ github.event.inputs.test_multi_files == 'true'}}
-        echo ${{ github.event.inputs.gitee_release_id }}
-        echo ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
-        echo ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
-        echo ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'false' }}
-        echo ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'true' }}
-        
-    - name: Test create release(Single file)
-      id: create_release
-      if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
+    - name: Test create release with single file
+      id: create_release_single
       uses: ./
       with:
         gitee_action: create_release
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_release_name: ${{ inputs.gitee_release_name }}
-        gitee_release_body: 'Gitee release 描述'
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+        gitee_release_name: Single File Test v1.0-${{ github.run_number }}
+        gitee_release_body: 'Gitee single file release test'
         gitee_target_commitish: master
-        gitee_file_name: ${{ inputs.gitee_file_name }}
-        gitee_file_path: ${{ inputs.gitee_file_path }}
+        gitee_file_name: 'single-test.txt'
+        gitee_file_path: 'LICENSE'
           
-    - name: Test create release(Multi file)
-      id: create_release_multi
-      if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
-      uses: ./
-      with:
-        gitee_action: create_release
-        gitee_owner: ${{ inputs.gitee_owner }}
-        gitee_repo: ${{ inputs.gitee_repo }}
-        gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_release_name: ${{ inputs.gitee_release_name }}
-        gitee_release_body: 'Gitee release 描述'
-        gitee_target_commitish: master
-        gitee_files: |
-          LICENSE
-          requirements.txt
-          .github/workflows/test.yml
-          
-    - name: Test upload single file to exist release - using release_id from last step
-      if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
+    - name: Test upload additional single file to existing release
       uses: ./
       with:
         gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_release_id: ${{ steps.create_release.outputs.release-id }}
-        gitee_file_name: ${{ inputs.gitee_file_name_new }}
-        gitee_file_path: ${{ inputs.gitee_file_path }}
+        gitee_release_id: ${{ steps.create_release_single.outputs.release-id }}
+        gitee_file_name: 'additional-single.txt'
+        gitee_file_path: 'README.md'
+
+    - name: Test upload using tag_name (single)
+      uses: ./
+      with:
+        gitee_action: upload_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+        gitee_file_name: 'tag-upload-single.txt'
+        gitee_file_path: 'action.yml'
+        
+    - name: Test update asset
+      uses: ./
+      with:
+        gitee_action: update_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+        gitee_old_asset_name: 'single-test.txt'
+        gitee_new_file_path: 'requirements.txt'
+        
+    - name: Test delete specific asset
+      uses: ./
+      with:
+        gitee_action: delete_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+        gitee_delete_assets: 'tag-upload-single.txt'
+        
+    - name: Test delete release
+      uses: ./
+      with:
+        gitee_action: delete_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+
+  # Job 2: 测试多文件创建release和相关操作
+  test-multi-file:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.ref }}
+        
+    - name: Test create release with multiple files
+      id: create_release_multi
+      uses: ./
+      with:
+        gitee_action: create_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-multi-${{ github.run_number }}
+        gitee_release_name: Multi File Test v1.0-${{ github.run_number }}
+        gitee_release_body: 'Gitee multi file release test'
+        gitee_target_commitish: master
+        gitee_files: |
+          LICENSE
+          README.md
+          action.yml
           
-    - name: Test upload multi file to exist release - using release_id from last step
-      if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
+    - name: Test upload additional multiple files to existing release
       uses: ./
       with:
         gitee_action: upload_asset
@@ -120,75 +123,91 @@ jobs:
         gitee_token: ${{ inputs.gitee_token }}
         gitee_release_id: ${{ steps.create_release_multi.outputs.release-id }}
         gitee_files: |
-          action.yml
-          README.md
-          
-    - name: Test upload single file to exist release - using release_id from inputs
-      if: ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'false' }}
-      uses: ./
-      with:
-        gitee_action: upload_asset
-        gitee_owner: ${{ inputs.gitee_owner }}
-        gitee_repo: ${{ inputs.gitee_repo }}
-        gitee_token: ${{ inputs.gitee_token }}
-        gitee_release_id: ${{ inputs.gitee_release_id }}
-        gitee_file_name: ${{ inputs.gitee_file_name_new }}
-        gitee_file_path: ${{ inputs.gitee_file_path }}
-        
-    - name: Test upload multi file to exist release - using release_id from inputs
-      if: ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'true' }}
-      uses: ./
-      with:
-        gitee_action: upload_asset
-        gitee_owner: ${{ inputs.gitee_owner }}
-        gitee_repo: ${{ inputs.gitee_repo }}
-        gitee_token: ${{ inputs.gitee_token }}
-        gitee_release_id: ${{ inputs.gitee_release_id }}
-        gitee_files: |
-          action.yml
-          README.md
+          requirements.txt
+          gitee_release.py
 
-    - name: Test upload using tag_name
-      if: ${{ inputs.gitee_release_id == '' }}
+    - name: Test upload using tag_name (multi)
       uses: ./
       with:
         gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_file_name: 'tag-upload-test.txt'
+        gitee_tag_name: v1.0-multi-${{ github.run_number }}
+        gitee_file_name: 'tag-upload-multi.txt'
         gitee_file_path: 'LICENSE'
         
-    - name: Test delete asset by tag_name and asset name
-      if: ${{ inputs.gitee_release_id == '' }}
+    - name: Test delete multiple assets
       uses: ./
       with:
         gitee_action: delete_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_delete_assets: 'tag-upload-test.txt'
+        gitee_tag_name: v1.0-multi-${{ github.run_number }}
+        gitee_delete_assets: |
+          tag-upload-multi.txt
+          LICENSE
         
-    - name: Test update asset by tag_name
-      if: ${{ inputs.gitee_release_id == '' }}
-      uses: ./
-      with:
-        gitee_action: update_asset
-        gitee_owner: ${{ inputs.gitee_owner }}
-        gitee_repo: ${{ inputs.gitee_repo }}
-        gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_old_asset_name: ${{ inputs.gitee_file_name }}
-        gitee_new_file_path: 'requirements.txt'
-        
-    - name: Test delete release by tag_name
-      if: ${{ inputs.gitee_release_id == '' }}
+    - name: Test delete release
       uses: ./
       with:
         gitee_action: delete_release
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
+        gitee_tag_name: v1.0-multi-${{ github.run_number }}
+
+  # Job 3: 测试使用已存在release ID的场景
+  test-existing-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.ref }}
+        
+    - name: Create base release for testing
+      id: create_base_release
+      uses: ./
+      with:
+        gitee_action: create_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-existing-${{ github.run_number }}
+        gitee_release_name: Existing Release Test v1.0-${{ github.run_number }}
+        gitee_release_body: 'Test using existing release ID'
+        gitee_target_commitish: master
+        
+    - name: Test upload single file to existing release by ID
+      uses: ./
+      with:
+        gitee_action: upload_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_release_id: ${{ steps.create_base_release.outputs.release-id }}
+        gitee_file_name: 'existing-single.txt'
+        gitee_file_path: 'LICENSE'
+        
+    - name: Test upload multiple files to existing release by ID
+      uses: ./
+      with:
+        gitee_action: upload_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_release_id: ${{ steps.create_base_release.outputs.release-id }}
+        gitee_files: |
+          README.md
+          action.yml
+          requirements.txt
+        
+    - name: Test delete release
+      uses: ./
+      with:
+        gitee_action: delete_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-existing-${{ github.run_number }}

--- a/.github/workflows/test_real.yml
+++ b/.github/workflows/test_real.yml
@@ -1,4 +1,4 @@
-name: Test(直接拉取项目)
+name: Comprehensive Test(直接拉取项目)
 on:
   workflow_dispatch:
     inputs: 
@@ -13,49 +13,20 @@ on:
       gitee_token:
         description: 'Gitee api token'
         required: true
-        
-      gitee_tag_name:
-        description: 'Gitee Tag 名称, 提倡以v字母为前缀做为Release名称，例如v1.0或者v2.3.4'
-        required: false
-        default: v1.0
-      gitee_release_name:
-        description: 'Gitee release 名称'
-        required: false
-        default: Test v1.0
-        
-      test_multi_files:
-        description: '测试多文件'
-        required: true
-        type: boolean
-        default: true
-        
-      gitee_release_id:
-        description: '上传附件对应的release的id。该值存在的话，不会再去尝试创建release。'
-        required: false
       gitee_upload_retry_times:
         description: '上传附件失败后的尝试次数'
         required: false
+        default: '2'
       runs_on:
         description: '测试平台 ubuntu-latest/windows-latest 等'
         required: true
         default: ubuntu-latest
         
 jobs:
-  release:
+  # Job 1: 测试单文件创建release和相关操作  
+  test-single-file:
     runs-on: ${{ inputs.runs_on }}
     steps:
-    - name: Echo inputs
-      run: |
-        echo ${{ inputs.runs_on }}
-        echo 1-${{ github.event.inputs.test_multi_files }}
-        echo 2-${{ github.event.inputs.test_multi_files == 'false'}}
-        echo 3-${{ github.event.inputs.test_multi_files == 'true'}}
-        echo 4-${{ github.event.inputs.gitee_release_id }}
-        echo 5-${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
-        echo 6-${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
-        echo 7-${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'false' }}
-        echo 8-${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'true' }}
-        
     - name: Create test files
       run: |
         mkdir test_dir
@@ -65,56 +36,109 @@ jobs:
         echo file3 > test_file3.txt
         echo file4 > test_file4.md
         
-    - name: Test create release(Single file)
-      id: create_release
-      if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
+    - name: Test create release with single file
+      id: create_release_single
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
         gitee_action: create_release
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_release_name: ${{ inputs.gitee_release_name }}
-        gitee_release_body: 'Gitee release 描述'
-        gitee_target_commitish: 
-        gitee_upload_retry_times:  ${{ inputs.gitee_upload_retry_times }}
-        gitee_file_name: 测试文件1.txt
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+        gitee_release_name: Single File Test v1.0-${{ github.run_number }}
+        gitee_release_body: Gitee single file release test
+        gitee_target_commitish: ""
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        gitee_file_name: 单文件测试.txt
         gitee_file_path: ./test_dir/test_file1.txt
           
-    - name: Test create release(Multi file)
-      id: create_release_multi
-      if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
-      uses: nicennnnnnnlee/action-gitee-release@master
-      with:
-        gitee_action: create_release
-        gitee_owner: ${{ inputs.gitee_owner }}
-        gitee_repo: ${{ inputs.gitee_repo }}
-        gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_release_name: ${{ inputs.gitee_release_name }}
-        gitee_release_body: 'Gitee release 描述'
-        gitee_target_commitish: 
-        gitee_upload_retry_times:  ${{ inputs.gitee_upload_retry_times }}
-        gitee_files: |
-          ./test_dir/test*.txt
-          ./test_dir/test*.md
-          
-    - name: Test upload single file to exist release - using last step id
-      if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
+    - name: Test upload additional single file to existing release
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
         gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_release_id: ${{ steps.create_release.outputs.release-id }}
-        gitee_upload_retry_times:  ${{ inputs.gitee_upload_retry_times }}
-        gitee_file_name: 测试文件2.txt
+        gitee_release_id: ${{ steps.create_release_single.outputs.release-id }}
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        gitee_file_name: 附加单文件.txt
         gitee_file_path: ./test_dir/test_file2.txt
+
+    - name: Test upload using tag_name (single)
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: upload_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        gitee_file_name: 标签上传测试.txt
+        gitee_file_path: ./test_dir/test_file3.txt
+        
+    - name: Test update asset
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: update_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+        gitee_old_asset_name: 单文件测试.txt
+        gitee_new_file_path: ./test_dir/test_file4.md
+        
+    - name: Test delete specific asset
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: delete_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+        gitee_delete_assets: 标签上传测试.txt
+        
+    - name: Test delete release
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: delete_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-single-${{ github.run_number }}
+
+  # Job 2: 测试多文件创建release和相关操作
+  test-multi-file:
+    runs-on: ${{ inputs.runs_on }}
+    steps:
+    - name: Create test files
+      run: |
+        mkdir test_dir
+        cd test_dir
+        echo file1 > test_file1.txt
+        echo file2 > test_file2.txt
+        echo file3 > test_file3.txt
+        echo file4 > test_file4.md
+        echo file5 > test_file5.txt
+        
+    - name: Test create release with multiple files
+      id: create_release_multi
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: create_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-multi-${{ github.run_number }}
+        gitee_release_name: Multi File Test v1.0-${{ github.run_number }}
+        gitee_release_body: Gitee multi file release test
+        gitee_target_commitish: ""
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        gitee_files: |
+          ./test_dir/test_file1.txt
+          ./test_dir/test_file2.txt
+          ./test_dir/test_file4.md
           
-    - name: Test upload multi file to exist release - using last step id
-      if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
+    - name: Test upload additional multiple files to existing release
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
         gitee_action: upload_asset
@@ -122,67 +146,102 @@ jobs:
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
         gitee_release_id: ${{ steps.create_release_multi.outputs.release-id }}
-        gitee_upload_retry_times:  ${{ inputs.gitee_upload_retry_times }}
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
         gitee_files: |
-          ./test_dir/test*.txt
-          ./test_dir/test*.md
-          
-    - name: Test upload single file to exist release - using id from inputs
-      if: ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'false' }}
+          ./test_dir/test_file3.txt
+          ./test_dir/test_file5.txt
+
+    - name: Test upload using tag_name (multi)
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
         gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_release_id: ${{ inputs.gitee_release_id }}
-        gitee_upload_retry_times:  ${{ inputs.gitee_upload_retry_times }}
-        gitee_file_name: 测试文件3.txt
-        gitee_file_path: ./test_dir/test_file3.txt
+        gitee_tag_name: v1.0-multi-${{ github.run_number }}
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        gitee_file_name: 多文件标签上传.txt
+        gitee_file_path: ./test_dir/test_file1.txt
         
-    - name: Test upload multi file to exist release - using id from inputs
-      if: ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'true' }}
-      uses: nicennnnnnnlee/action-gitee-release@master
-      with:
-        gitee_action: upload_asset
-        gitee_owner: ${{ inputs.gitee_owner }}
-        gitee_repo: ${{ inputs.gitee_repo }}
-        gitee_token: ${{ inputs.gitee_token }}
-        gitee_release_id: ${{ inputs.gitee_release_id }}
-        gitee_upload_retry_times:  ${{ inputs.gitee_upload_retry_times }}
-        gitee_files: |
-          ./test_dir/test*.txt
-          ./test_dir/test*.md
-
-    - name: Test delete release by tag
-      if: ${{ github.event.inputs.test_multi_files == 'true' }}
-      uses: nicennnnnnnlee/action-gitee-release@master
-      with:
-        gitee_action: delete_release
-        gitee_owner: ${{ inputs.gitee_owner }}
-        gitee_repo: ${{ inputs.gitee_repo }}
-        gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-
-    - name: Test delete asset by tag and name
-      if: ${{ github.event.inputs.test_multi_files == 'true' }}
+    - name: Test delete multiple assets
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
         gitee_action: delete_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_delete_assets: 测试文件1.txt
-
-    - name: Test update asset by tag and old name
-      if: ${{ github.event.inputs.test_multi_files == 'true' }}
+        gitee_tag_name: v1.0-multi-${{ github.run_number }}
+        gitee_delete_assets: |
+          多文件标签上传.txt
+          test_file1.txt
+        
+    - name: Test delete release
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
-        gitee_action: update_asset
+        gitee_action: delete_release
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
-        gitee_tag_name: ${{ inputs.gitee_tag_name }}
-        gitee_old_asset_name: 测试文件1.txt
-        gitee_new_file_path: ./test_dir/test_file4.md
+        gitee_tag_name: v1.0-multi-${{ github.run_number }}
+
+  # Job 3: 测试使用已存在release ID的场景
+  test-existing-release:
+    runs-on: ${{ inputs.runs_on }}
+    steps:
+    - name: Create test files
+      run: |
+        mkdir test_dir
+        cd test_dir
+        echo file1 > test_file1.txt
+        echo file2 > test_file2.txt
+        echo file3 > test_file3.txt
+        echo file4 > test_file4.md
+        
+    - name: Create base release for testing
+      id: create_base_release
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: create_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-existing-${{ github.run_number }}
+        gitee_release_name: Existing Release Test v1.0-${{ github.run_number }}
+        gitee_release_body: Test using existing release ID
+        gitee_target_commitish: ""
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        
+    - name: Test upload single file to existing release by ID
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: upload_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_release_id: ${{ steps.create_base_release.outputs.release-id }}
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        gitee_file_name: 已存在ID单文件.txt
+        gitee_file_path: ./test_dir/test_file1.txt
+        
+    - name: Test upload multiple files to existing release by ID
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: upload_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_release_id: ${{ steps.create_base_release.outputs.release-id }}
+        gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        gitee_files: |
+          ./test_dir/test_file2.txt
+          ./test_dir/test_file3.txt
+          ./test_dir/test_file4.md
+        
+    - name: Test delete release
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: delete_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: v1.0-existing-${{ github.run_number }}

--- a/.github/workflows/test_real.yml
+++ b/.github/workflows/test_real.yml
@@ -70,6 +70,7 @@ jobs:
       if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
+        gitee_action: create_release
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -86,6 +87,7 @@ jobs:
       if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
+        gitee_action: create_release
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -102,6 +104,7 @@ jobs:
       if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'false' }}
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
+        gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -114,6 +117,7 @@ jobs:
       if: ${{ inputs.gitee_release_id == '' && github.event.inputs.test_multi_files == 'true' }}
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
+        gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -127,6 +131,7 @@ jobs:
       if: ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'false' }}
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
+        gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -139,6 +144,7 @@ jobs:
       if: ${{ inputs.gitee_release_id != '' && github.event.inputs.test_multi_files == 'true' }}
       uses: nicennnnnnnlee/action-gitee-release@master
       with:
+        gitee_action: upload_asset
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -147,3 +153,36 @@ jobs:
         gitee_files: |
           ./test_dir/test*.txt
           ./test_dir/test*.md
+
+    - name: Test delete release by tag
+      if: ${{ github.event.inputs.test_multi_files == 'true' }}
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: delete_release
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: ${{ inputs.gitee_tag_name }}
+
+    - name: Test delete asset by tag and name
+      if: ${{ github.event.inputs.test_multi_files == 'true' }}
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: delete_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: ${{ inputs.gitee_tag_name }}
+        gitee_delete_assets: 测试文件1.txt
+
+    - name: Test update asset by tag and old name
+      if: ${{ github.event.inputs.test_multi_files == 'true' }}
+      uses: nicennnnnnnlee/action-gitee-release@master
+      with:
+        gitee_action: update_asset
+        gitee_owner: ${{ inputs.gitee_owner }}
+        gitee_repo: ${{ inputs.gitee_repo }}
+        gitee_token: ${{ inputs.gitee_token }}
+        gitee_tag_name: ${{ inputs.gitee_tag_name }}
+        gitee_old_asset_name: 测试文件1.txt
+        gitee_new_file_path: ./test_dir/test_file4.md

--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
 # action-gitee-release
-在Gitee项目发布release(可以上传附件)
+
+在 Gitee 项目发布、更新、删除 release
+
+## 功能概览
+
+支持以下 5 种操作，通过 `gitee_action` 参数指定：
+
+- `create_release`: 创建 release，可选择性上传附件
+- `upload_asset`: 向已有 release 上传附件（通过 tag 或 id 定位）
+- `delete_release`: 删除指定 tag 的 release
+- `delete_asset`: 删除指定 release 的指定附件（支持多个）
+- `update_asset`: 更新指定 release 的指定附件
 
 ## 示例
 
-### 仅创建release
-```
-- name: Test create release
-  id: create_release
-  uses: nicennnnnnnlee/action-gitee-release@v1.0.5
+### 1. 仅创建 release
+
+```yaml
+- name: Create Release Only
+  uses: nicennnnnnnlee/action-gitee-release@master
   with:
+    gitee_action: create_release
     gitee_owner: Gitee用户名
     gitee_repo: Gitee项目名
     gitee_token: ${{ secrets.gitee_token }}
@@ -18,12 +30,13 @@
     gitee_target_commitish: master
 ```
 
-### 创建release，并上传单个附件
-```
-- name: Test create release
-  id: create_release
-  uses: nicennnnnnnlee/action-gitee-release@v1.0.5
+### 2. 创建 release 并上传单个附件
+
+```yaml
+- name: Create Release with Single File
+  uses: nicennnnnnnlee/action-gitee-release@master
   with:
+    gitee_action: create_release
     gitee_owner: Gitee用户名
     gitee_repo: Gitee项目名
     gitee_token: ${{ secrets.gitee_token }}
@@ -31,17 +44,18 @@
     gitee_release_name: Test v1.0.0
     gitee_release_body: Release 描述
     gitee_target_commitish: master
-    gitee_upload_retry_times:  3
+    gitee_upload_retry_times: 3
     gitee_file_name: 文件名称
     gitee_file_path: 文件本地路径
 ```
 
-### 创建release，并上传多个附件
-```
-- name: Test create release
-  id: create_release
-  uses: nicennnnnnnlee/action-gitee-release@v1.0.5
+### 3. 创建 release 并上传多个附件
+
+```yaml
+- name: Create Release with Multiple Files
+  uses: nicennnnnnnlee/action-gitee-release@master
   with:
+    gitee_action: create_release
     gitee_owner: Gitee用户名
     gitee_repo: Gitee项目名
     gitee_token: ${{ secrets.gitee_token }}
@@ -49,81 +63,124 @@
     gitee_release_name: Test v1.0.0
     gitee_release_body: Release 描述
     gitee_target_commitish: master
-    gitee_upload_retry_times:  3
+    gitee_upload_retry_times: 3
     gitee_files: |
-        文件路径1
-        文件路径2
+      文件路径1
+      文件路径2
 ```
 
+### 4.1. 向已有 release 上传附件（通过 tag 定位）
 
-### 上传单个附件到现有项目
-```
-- name: Test create release
-  id: create_release
-  uses: nicennnnnnnlee/action-gitee-release@v1.0.5
+```yaml
+- name: Upload Assets to Existing Release by Tag
+  uses: nicennnnnnnlee/action-gitee-release@master
   with:
+    gitee_action: upload_asset
     gitee_owner: Gitee用户名
     gitee_repo: Gitee项目名
     gitee_token: ${{ secrets.gitee_token }}
     gitee_tag_name: v1.0.0
-    gitee_release_name: Test v1.0.0
-    gitee_release_body: Release 描述
-    gitee_target_commitish: master
-    gitee_upload_retry_times:  3
-      
-- name: Test upload file to exist release
-  uses: nicennnnnnnlee/action-gitee-release@v1.0.5
-  with:
-    gitee_owner: Gitee用户名
-    gitee_repo: Gitee项目名
-    gitee_token: ${{ secrets.gitee_token }}
-    gitee_release_id: ${{ steps.create_release.outputs.release-id }}
-    gitee_file_name: 文件名称1
-    gitee_file_path: 文件本地路径1
-    gitee_upload_retry_times:  3
-```
-
-### 上传多个附件到现有项目
-```
-- name: Test create release
-  id: create_release
-  uses: nicennnnnnnlee/action-gitee-release@v1.0.5
-  with:
-    gitee_owner: Gitee用户名
-    gitee_repo: Gitee项目名
-    gitee_token: ${{ secrets.gitee_token }}
-    gitee_tag_name: v1.0.0
-    gitee_release_name: Test v1.0.0
-    gitee_release_body: Release 描述
-    gitee_target_commitish: master
-
-      
-- name: Test upload file to exist release
-  uses: nicennnnnnnlee/action-gitee-release@v1.0.5
-  with:
-    gitee_owner: Gitee用户名
-    gitee_repo: Gitee项目名
-    gitee_token: ${{ secrets.gitee_token }}
-    gitee_release_id: ${{ steps.create_release.outputs.release-id }}
-    gitee_upload_retry_times:  3
+    gitee_upload_retry_times: 3
     gitee_files: |
-        文件路径1
-        文件路径2
+      文件路径1
+      文件路径2
 ```
 
+### 4.1. 向已有 release 上传附件（通过 release_id 定位）
 
-- `gitee_owner`：Gitee 用户名, 项目URL中可获取
-- `gitee_repo`：Gitee 项目名, 项目URL中可获取
+```yaml
+- name: Upload Assets to Existing Release by ID
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: upload_asset
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_release_id: 12345
+    gitee_upload_retry_times: 3
+    gitee_files: |
+      文件路径1
+      文件路径2
+```
+
+### 5. 删除指定 tag 的 release
+
+```yaml
+- name: Delete Release
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: delete_release
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_tag_name: v1.0.0
+```
+
+### 6. 删除 release 中的附件
+
+```yaml
+- name: Delete Multiple Assets
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: delete_asset
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_tag_name: v1.0.0
+    gitee_delete_assets: |
+      文件名1
+      文件名2
+      文件名3
+```
+
+### 7. 更新 release 中的附件
+
+```yaml
+- name: Update Asset
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: update_asset
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_tag_name: v1.0.0
+    gitee_old_asset_name: 旧文件名称
+    gitee_new_file_path: 新文件本地路径
+```
+
+## 参数说明
+
+### 通用参数
+
+- `gitee_action`：执行的操作类型，可选值：`create_release`, `upload_asset`, `delete_release`, `delete_asset`, `update_asset`
+- `gitee_owner`：Gitee 用户名, 项目 URL 中可获取
+- `gitee_repo`：Gitee 项目名, 项目 URL 中可获取
 - `gitee_token`：Gitee api token
-- `gitee_tag_name`：Gitee Tag 名称, 提倡以v字母为前缀做为Release名称，例如v1.0或者v2.3.4
+- `gitee_tag_name`：Gitee Tag 名称, 提倡以 v 字母为前缀做为 Release 名称，例如 v1.0 或者 v2.3.4
+
+### create_release 专用参数
+
 - `gitee_release_name`：Gitee release 名称
 - `gitee_release_body`：Gitee release 描述
-- `gitee_target_commitish`：Gitee 分支名称或者commit SHA
+- `gitee_target_commitish`：Gitee 分支名称或者 commit SHA
+
+### 文件上传相关参数（create_release, upload_asset 可用）
+
 - `gitee_files`：上传的附件列表(多个文件)。此处的文件路径支持规则匹配，参考[python-glob](https://docs.python.org/zh-cn/dev/library/glob.html)
 - `gitee_file_name`：上传的附件名称(单个文件)
 - `gitee_file_path`：上传的附件的本地路径(单个文件)
-- `gitee_release_id`：上传附件对应的release的id。该值存在的话，不会再去尝试创建release。
-- `gitee_upload_retry_times`：上传附件失败后的尝试次数。默认为0，不再尝试。
-- 注意：Token需要以 [Secrets](https://docs.github.com/cn/actions/reference/encrypted-secrets) 方式给出，以保证token不被泄露
+- `gitee_release_id`：指定的 release ID (仅 upload_asset 操作时可用，如果指定则优先使用，否则通过 tag_name 查找)
+- `gitee_upload_retry_times`：上传附件失败后的尝试次数。默认为 0，不再尝试。
 
+### delete_asset 专用参数
 
+- `gitee_delete_assets`：要删除的附件名称，每行一个文件名
+
+### update_asset 专用参数
+
+- `gitee_old_asset_name`：要更新的旧附件名称
+- `gitee_new_file_path`：新附件的本地路径
+
+## 注意事项
+
+- Token 需要以 [Secrets](https://docs.github.com/cn/actions/reference/encrypted-secrets) 方式给出，以保证 token 不被泄露

--- a/README.md
+++ b/README.md
@@ -69,10 +69,26 @@
       文件路径2
 ```
 
-### 4.1. 向已有 release 上传附件（通过 tag 定位）
+### 4.1. 向已有 release 上传单个附件（通过 tag 定位）
 
 ```yaml
-- name: Upload Assets to Existing Release by Tag
+- name: Upload Single Asset to Existing Release by Tag
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: upload_asset
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_tag_name: v1.0.0
+    gitee_upload_retry_times: 3
+    gitee_file_name: 新附件名称
+    gitee_file_path: 新附件本地路径
+```
+
+### 4.2. 向已有 release 上传多个附件（通过 tag 定位）
+
+```yaml
+- name: Upload Multiple Assets to Existing Release by Tag
   uses: nicennnnnnnlee/action-gitee-release@master
   with:
     gitee_action: upload_asset
@@ -86,10 +102,26 @@
       文件路径2
 ```
 
-### 4.1. 向已有 release 上传附件（通过 release_id 定位）
+### 4.3. 向已有 release 上传单个附件（通过 release_id 定位）
 
 ```yaml
-- name: Upload Assets to Existing Release by ID
+- name: Upload Single Asset to Existing Release by ID
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: upload_asset
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_release_id: 12345
+    gitee_upload_retry_times: 3
+    gitee_file_name: 新附件名称
+    gitee_file_path: 新附件本地路径
+```
+
+### 4.4. 向已有 release 上传多个附件（通过 release_id 定位）
+
+```yaml
+- name: Upload Multiple Assets to Existing Release by ID
   uses: nicennnnnnnlee/action-gitee-release@master
   with:
     gitee_action: upload_asset
@@ -116,7 +148,21 @@
     gitee_tag_name: v1.0.0
 ```
 
-### 6. 删除 release 中的附件
+### 6.1. 删除 release 中的单个附件
+
+```yaml
+- name: Delete Single Asset
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: delete_asset
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_tag_name: v1.0.0
+    gitee_delete_assets: 文件名
+```
+
+### 6.2. 删除 release 中的多个附件
 
 ```yaml
 - name: Delete Multiple Assets
@@ -146,6 +192,35 @@
     gitee_tag_name: v1.0.0
     gitee_old_asset_name: 旧文件名称
     gitee_new_file_path: 新文件本地路径
+```
+
+### 8. 使用 Action 输出的综合示例
+
+```yaml
+- name: Create Release and Use Output
+  id: create_release
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: create_release
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_tag_name: v1.0.0
+    gitee_release_name: Test v1.0.0
+    gitee_release_body: Release 描述
+    gitee_target_commitish: master
+
+- name: Upload Additional Assets Using Release ID
+  uses: nicennnnnnnlee/action-gitee-release@master
+  with:
+    gitee_action: upload_asset
+    gitee_owner: Gitee用户名
+    gitee_repo: Gitee项目名
+    gitee_token: ${{ secrets.gitee_token }}
+    gitee_release_id: ${{ steps.create_release.outputs.release-id }}
+    gitee_files: |
+      additional_file1.txt
+      additional_file2.txt
 ```
 
 ## 参数说明
@@ -180,6 +255,12 @@
 
 - `gitee_old_asset_name`：要更新的旧附件名称
 - `gitee_new_file_path`：新附件的本地路径
+
+## 输出说明
+
+### create_release 操作输出
+
+- `release-id`：创建的 release 的 ID，可用于后续的 upload_asset 操作
 
 ## 注意事项
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'action-gitee-release'
 description: '在Gitee项目发布release(可以上传附件)'
 inputs:
+  gitee_action:
+    description: '执行的操作类型: create_release, upload_asset, delete_release, delete_asset, update_asset'
+    required: true
 
   gitee_owner:
     description: 'Gitee 用户名, 项目URL中可获取'
@@ -37,11 +40,25 @@ inputs:
     required: false
     
   gitee_release_id:
-    description: '上传附件对应的release的id。该值存在的话，不会再去尝试创建release。'
+    description: '指定的release ID (upload_asset操作时可选，优先级高于tag_name)'
     required: false
-  
+    
   gitee_upload_retry_times:
     description: '上传附件失败后的尝试次数'
+    required: false
+
+  gitee_delete_asset:
+    description: '要删除的单个附件名称 (delete_asset操作时使用)'
+    required: false
+  gitee_delete_assets:
+    description: '要删除的多个附件名称，每行一个文件名 (delete_asset操作时使用)'
+    required: false
+    
+  gitee_old_asset_name:
+    description: '要更新的旧附件名称 (update_asset操作时使用)'
+    required: false
+  gitee_new_file_path:
+    description: '新附件的本地路径 (update_asset操作时使用)'
     required: false
     
 outputs:
@@ -54,10 +71,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Create release or Upload assets
+    - name: Execute Gitee Release Action
       id: release
       shell: bash
       env:
+        gitee_action: ${{ inputs.gitee_action }}
         gitee_owner: ${{ inputs.gitee_owner }}
         gitee_repo: ${{ inputs.gitee_repo }}
         gitee_token: ${{ inputs.gitee_token }}
@@ -70,6 +88,10 @@ runs:
         gitee_file_path: ${{ inputs.gitee_file_path }}
         gitee_release_id: ${{ inputs.gitee_release_id }}
         gitee_upload_retry_times: ${{ inputs.gitee_upload_retry_times }}
+        gitee_delete_asset: ${{ inputs.gitee_delete_asset }}
+        gitee_delete_assets: ${{ inputs.gitee_delete_assets }}
+        gitee_old_asset_name: ${{ inputs.gitee_old_asset_name }}
+        gitee_new_file_path: ${{ inputs.gitee_new_file_path }}
       run: |
         pip install -r "${{ github.action_path }}/requirements.txt"
         python "${{ github.action_path }}/gitee_release.py"

--- a/gitee_release.py
+++ b/gitee_release.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python
 # coding:utf-8
-import os, glob
-import requests,json,time
+import os
+import glob
+import requests
+import time
 from requests_toolbelt import MultipartEncoder
 from functools import wraps
 
 retry_times = os.environ.get("gitee_upload_retry_times", "0")
 try:
     retry_times = int(retry_times)
-except:
+except Exception:
     retry_times = 0
     
 def Retry(retry, include_exceptions = [Exception], exclude_exceptions = [ValueError], sleep = 1):
@@ -61,7 +63,7 @@ class Gitee:
         }
         response = requests.post(url, data=data)
         res = response.json() 
-        if response.status_code < 200 or response.status_code > 300:
+        if response.status_code < 200 or response.status_code >= 300:
             return False, res["message"] if "message" in res else f"Response status_code is {response.status_code}"
         
         if "id" in res:
@@ -74,32 +76,122 @@ class Gitee:
         if files:
             fields = [('access_token', self.token)]
             idx = 1
-            for file_path in files:
-                file_path = file_path.strip()
-                if not os.path.isfile(file_path):
-                    raise ValueError('file_path not exists: ' + file_path)
-                file = ('file', (os.path.basename(file_path), open(file_path, 'rb'), 'application/octet-stream'))
-                idx = idx + 1
-                fields.append(file)
+            file_handles = []  # Track file handles for proper cleanup
+            try:
+                for file_path in files:
+                    file_path = file_path.strip()
+                    if not os.path.isfile(file_path):
+                        raise ValueError('file_path not exists: ' + file_path)
+                    file_handle = open(file_path, 'rb')
+                    file_handles.append(file_handle)
+                    file = ('file', (os.path.basename(file_path), file_handle, 'application/octet-stream'))
+                    idx = idx + 1
+                    fields.append(file)
+                
+                m = MultipartEncoder(fields=fields)
+                url = f"https://gitee.com/api/v5/repos/{self.owner}/{repo}/releases/{release_id}/attach_files"
+                response = requests.post(url, data=m, headers={'Content-Type': m.content_type})
+            finally:
+                # Close all file handles
+                for handle in file_handles:
+                    handle.close()
         elif file_name and file_path:
-            fields = {
-                'access_token': self.token,
-                'file': (file_name, open(file_path, 'rb'), 'application/octet-stream'),
-            }
+            with open(file_path, 'rb') as f:
+                fields = {
+                    'access_token': self.token,
+                    'file': (file_name, f, 'application/octet-stream'),
+                }
+                m = MultipartEncoder(fields=fields)
+                url = f"https://gitee.com/api/v5/repos/{self.owner}/{repo}/releases/{release_id}/attach_files"
+                response = requests.post(url, data=m, headers={'Content-Type': m.content_type})
         else:
             raise ValueError('files or (file_name and file_path) should not be False at the same time')
-        m = MultipartEncoder(fields=fields)
-        url = f"https://gitee.com/api/v5/repos/{self.owner}/{repo}/releases/{release_id}/attach_files"
-        response = requests.post(url, data=m, headers={'Content-Type': m.content_type})
+        
         # print(response.text)
         res = response.json()
-        if response.status_code < 200 or response.status_code > 300:
+        if response.status_code < 200 or response.status_code >= 300:
             return False, res["message"] if "message" in res else f"Response status_code is {response.status_code}"
         
         if "browser_download_url" in res:
             return True, res["browser_download_url"]
         else:
             return False, "No 'browser_download_url' in response"
+
+    def get_release_by_tag(self, repo, tag_name):
+        url = f'https://gitee.com/api/v5/repos/{self.owner}/{repo}/releases/tags/{tag_name}'
+        params = {'access_token': self.token}
+        response = requests.get(url, params=params)
+        res = response.json()
+        if response.status_code != 200:
+            return False, res.get("message", f"Status code {response.status_code}")
+        if "id" in res:
+            return True, res["id"]
+        else:
+            return False, "No release id found"
+
+    def get_asset_id(self, repo, release_id, filename):
+        url = f'https://gitee.com/api/v5/repos/{self.owner}/{repo}/releases/{release_id}/attach_files'
+        params = {'access_token': self.token, "per_page": 100}
+        response = requests.get(url, params=params)
+        res = response.json()
+        if response.status_code != 200:
+            return False, res.get("message", f"Status code {response.status_code}")
+        for asset in res:
+            if asset['name'] == filename:
+                return True, asset['id']
+        return False, "Asset not found"
+
+    @Retry(retry_times)
+    def update_asset(self, repo, tag_name, filename, new_file_path):
+        success, release_id = self.get_release_by_tag(repo, tag_name)
+        if not success:
+            return False, release_id
+        
+        success, asset_id = self.get_asset_id(repo, release_id, filename)
+        if not success:
+            return False, asset_id
+        
+        success, msg = self.delete_asset(repo, release_id, asset_id)
+        if not success:
+            return False, msg
+        
+        return self.upload_asset(repo, release_id, file_name=filename, file_path=new_file_path)
+
+    def delete_release_by_tag(self, repo, tag_name):
+        success, release_id = self.get_release_by_tag(repo, tag_name)
+        if not success:
+            return False, release_id
+        return self.delete_release(repo, release_id)
+
+    def delete_release(self, repo, release_id):
+        url = f'https://gitee.com/api/v5/repos/{self.owner}/{repo}/releases/{release_id}'
+        params = {'access_token': self.token}
+        response = requests.delete(url, params=params)
+        if response.status_code == 204:
+            return True, "Release deleted successfully"
+        else:
+            res = response.json()
+            return False, res.get("message", f"Status code {response.status_code}")
+
+    def delete_asset_by_filename(self, repo, tag_name, filename):
+        success, release_id = self.get_release_by_tag(repo, tag_name)
+        if not success:
+            return False, release_id
+        
+        success, asset_id = self.get_asset_id(repo, release_id, filename)
+        if not success:
+            return False, asset_id
+        return self.delete_asset(repo, release_id, asset_id)
+
+    def delete_asset(self, repo, release_id, asset_id):
+        url = f'https://gitee.com/api/v5/repos/{self.owner}/{repo}/releases/{release_id}/attach_files/{asset_id}'
+        params = {'access_token': self.token}
+        response = requests.delete(url, params=params)
+        if response.status_code == 204:
+            return True, "Asset deleted successfully"
+        else:
+            res = response.json()
+            return False, res.get("message", f"Status code {response.status_code}")
 
 def get(key):
     val = os.environ.get(key)
@@ -112,7 +204,7 @@ def set_result(name, result):
     github_out = os.environ.get("GITHUB_OUTPUT")
     if github_out:
         with open(github_out, 'a', encoding='utf-8') as output:
-            if not '\n' in str(result):
+            if '\n' not in str(result):
                 output.write(f"{name}={result}\n")
                 print(f"{name}={result}\n")
             else:
@@ -163,26 +255,37 @@ def create_release():
     success, release_id = gitee_client.create_release(repo = gitee_repo, tag_name = gitee_tag_name, name = gitee_release_name, 
                 body = gitee_release_body, target_commitish = gitee_target_commitish)
     if success:
-        print(release_id)
+        print(f"Release created successfully with ID: {release_id}")
+        set_result("release-id", release_id)
+        
+        # Upload files if provided
         if gitee_files:
-            upload_assets(gitee_files, gitee_client, gitee_repo, release_id)
+            result = upload_assets(gitee_files, gitee_client, gitee_repo, release_id)
+            if result:
+                set_result("download-url", '\n'.join(result))
         elif gitee_file_path:
             success, msg = gitee_client.upload_asset(gitee_repo, release_id, file_name = gitee_file_name, file_path = gitee_file_path)
             if not success:
                 raise Exception("Upload file asset failed: " + msg)
-        set_result("release-id", release_id)
+            set_result("download-url", msg)
     else:
-        raise Exception("Create release failed: " + release_id)
+        raise Exception("Create release failed: " + str(release_id))
 
 def upload_asset():
-    gitee_release_id = get('gitee_release_id')
     gitee_owner = get('gitee_owner')
     gitee_repo = get('gitee_repo')
     gitee_token = get('gitee_token')
-        
     gitee_files = os.environ.get('gitee_files')
     
     gitee_client = Gitee(owner = gitee_owner, token = gitee_token)
+
+    gitee_release_id = os.environ.get('gitee_release_id')
+    if not gitee_release_id:
+        gitee_tag_name = get('gitee_tag_name')
+        success, gitee_release_id = gitee_client.get_release_by_tag(gitee_repo, gitee_tag_name)
+        if not success:
+            raise Exception(f"Failed to get release by tag {gitee_tag_name}")
+
     if gitee_files:
         gitee_files = gitee_files.strip().split("\n")
         result = upload_assets(gitee_files, gitee_client, gitee_repo, gitee_release_id)
@@ -196,11 +299,66 @@ def upload_asset():
         if not success:
             raise Exception("Upload file asset failed: " + msg)
         set_result("download-url", msg)
+
+def delete_release():
+    gitee_owner = get('gitee_owner')
+    gitee_repo = get('gitee_repo')
+    gitee_token = get('gitee_token')
+    gitee_tag_name = get('gitee_tag_name')
+    
+    gitee_client = Gitee(owner=gitee_owner, token=gitee_token)
+    success, msg = gitee_client.delete_release_by_tag(gitee_repo, gitee_tag_name)
+    if not success:
+        raise Exception("Delete release failed: " + msg)
+    print("Release deleted successfully")
+
+def delete_asset():
+    gitee_owner = get('gitee_owner')
+    gitee_repo = get('gitee_repo')
+    gitee_token = get('gitee_token')
+    gitee_tag_name = get('gitee_tag_name')
+    
+    gitee_delete_assets = get('gitee_delete_assets')
+    asset_names = [name.strip() for name in gitee_delete_assets.strip().split('\n') if name.strip()]
+    
+    gitee_client = Gitee(owner=gitee_owner, token=gitee_token)
+    
+    for asset_name in asset_names:
+        success, msg = gitee_client.delete_asset_by_filename(gitee_repo, gitee_tag_name, asset_name)
+        if not success:
+            raise Exception(f"Delete asset {asset_name} failed: " + msg)
+        print(f"Asset {asset_name} deleted successfully")
+
+def update_asset():
+    gitee_owner = get('gitee_owner')
+    gitee_repo = get('gitee_repo')
+    gitee_token = get('gitee_token')
+    gitee_tag_name = get('gitee_tag_name')
+    gitee_old_asset_name = get('gitee_old_asset_name')
+    gitee_new_file_path = get('gitee_new_file_path')
+    
+    if not os.path.isfile(gitee_new_file_path):
+        raise ValueError('gitee_new_file_path not exists: ' + gitee_new_file_path)
+    
+    gitee_client = Gitee(owner=gitee_owner, token=gitee_token)
+    success, msg = gitee_client.update_asset(gitee_repo, gitee_tag_name, gitee_old_asset_name, gitee_new_file_path)
+    if not success:
+        raise Exception("Update asset failed: " + msg)
+    print(f"Asset {gitee_old_asset_name} updated successfully")
+    set_result("download-url", msg)
         
 if __name__ == "__main__":
-    gitee_release_id = os.environ.get("gitee_release_id")
-    # print("gitee_release_id: ", gitee_release_id)
-    if gitee_release_id:
-        upload_asset()
-    else:
+    gitee_action = os.environ.get("gitee_action")
+    
+    if gitee_action == "create_release":
         create_release()
+    elif gitee_action == "upload_asset":
+        upload_asset()
+    elif gitee_action == "delete_release":
+        delete_release()
+    elif gitee_action == "delete_asset":
+        delete_asset()
+    elif gitee_action == "update_asset":
+        update_asset()
+    else:
+        raise ValueError(f"Unknown action: {gitee_action}. Supported actions: create_release, upload_asset, delete_release, delete_asset, update_asset")


### PR DESCRIPTION
您好，我给这个action添加了更新删除release的功能，还有些别的改动，具体为：

1. 根据tag_name指定release上传附件
2. 删除指定release
3. 删除指定release的指定附件
4. 更新指定release的指定附件
5. 将测试流程改成一次性触发

因为我自己有更新附件的需要，Gitee没有更新API，只能删除再上传附件，正好issue也有人需要删除，就做了这些。因为部分内容是AI生成的，改动比较多，但test.yaml的测试是都能通过的。您测一下test_real，再根据版本号改下README大概就可以了。